### PR TITLE
fix: eliminate temp directory in install.sh, use atomic mv

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,21 +45,20 @@ get_latest_version() {
 install() {
   local filename="moon-traveler-${VERSION}-${PLATFORM}"
   local url="https://github.com/$REPO/releases/download/$VERSION/$filename"
+  local dest="$INSTALL_DIR/moon-traveler"
 
   dim "Downloading $filename..."
-  TMPDIR_INSTALL="$(mktemp -d)"
-  trap 'rm -rf "$TMPDIR_INSTALL"' EXIT
+  mkdir -p "$INSTALL_DIR"
+  TMP_DEST="${dest}.tmp.$$"
+  trap 'rm -f "$TMP_DEST"' EXIT
 
-  curl -fSL --progress-bar -o "$TMPDIR_INSTALL/$filename" "$url" || {
+  curl -fSL --progress-bar -o "$TMP_DEST" "$url" || {
     red "Download failed: $url"
     red "Check https://github.com/$REPO/releases for available downloads."
     exit 1
   }
 
-  # Install binary
-  mkdir -p "$INSTALL_DIR"
-  local dest="$INSTALL_DIR/moon-traveler"
-  cp "$TMPDIR_INSTALL/$filename" "$dest"
+  mv "$TMP_DEST" "$dest"
   chmod +x "$dest"
 
   echo


### PR DESCRIPTION
Fixes #60

## What this changes

`install()` previously created a temp directory with `mktemp -d`, downloaded the binary into it, then `cp`'d it to the final location, and let the EXIT trap `rm -rf` the temp dir. Since the binary is now a single-file PyApp download with no extraction step, the temp directory is an unnecessary intermediary.

This PR replaces that pattern with a temp file written directly into the install directory (`$dest.tmp.$$`), then atomically renamed with `mv`. Because the temp file and destination share the same directory — and therefore the same filesystem — `mv` resolves to a POSIX `rename()` call, which is atomic.

**Changes in `install()`:**
- Remove `mktemp -d` and its `rm -rf` EXIT trap
- Add `TMP_DEST="${dest}.tmp.$$"` with a `rm -f` EXIT trap (single file, not a tree)
- Download directly to `TMP_DEST`; rename to `dest` on success

## Why this matters

The original bug in #60 was a symlink pointing into a temp dir that the EXIT trap deleted. The `cp`-based fix already closed the exploitable path, but the temp directory and its `rm -rf` cleanup were still present. Downloading directly to the install directory and using `mv` removes that structural risk entirely — if the EXIT trap ever fires prematurely, only one partial temp file is cleaned up, not a whole tree.

## One thing to flag

`TMP_DEST` is a global variable (no `local`) so the EXIT trap can resolve it at fire time — the same approach the original code used for `TMPDIR_INSTALL`. This is fine for the intended `curl | bash` one-shot usage, but if the script were ever sourced into a long-lived shell and `install()` called more than once, the trap would see the value from the most recent call. I might be wrong about whether that matters in practice here, so happy to adjust if you prefer a different cleanup strategy.

## Testing

I verified the logic on paper:
- `mkdir -p "$INSTALL_DIR"` runs before `TMP_DEST` is assigned, so the destination directory exists before download
- On download failure, EXIT trap `rm -f`s the partial file
- On success, `mv` atomically promotes the binary and the trap is a no-op (`rm -f` on a non-existent file exits 0)
- Concurrent installs won't collide: `$$` is unique per process

If this direction doesn't fit, no problem — happy to close and let you handle it differently.

---

*This PR was drafted with AI assistance (Claude Sonnet 4.6). The diff and reasoning were reviewed before submission.*