### PR TITLE
feat: CLI argparse, beta installs, binary self-upgrade, SHA-256 checksum validation

### DIFF
--- a/HOW_TO_PLAY.md
+++ b/HOW_TO_PLAY.md
@@ -568,11 +568,24 @@ Models placed in the legacy `models/` directory (project root) are still detecte
 ### Command-line flags
 
 ```
-python play_tui.py                    # normal launch
-python play_tui.py --upgrade          # check for updates and exit
-python play_tui.py --disable-animation  # launch with animations off
-python play_tui.py --dev              # launch with dev diagnostics on
+moon-traveler --help              # show all options
+moon-traveler --dev               # launch with dev diagnostics on
+moon-traveler --super             # max trust, all items (testing)
+moon-traveler --upgrade           # check for updates and exit
+moon-traveler --disable-animation # launch with animations off
 ```
+
+### PyApp management (binary installs only)
+
+Binary builds include built-in management commands:
+
+```
+moon-traveler self remove    # remove cached Python environment and packages
+moon-traveler self update    # update the embedded application
+moon-traveler self restore   # restore the cached environment
+```
+
+To fully uninstall: run `moon-traveler self remove`, delete the binary, and remove `~/.moonwalker/`.
 
 ### Game crashes or freezes during conversation
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,19 @@ Build trust with creatures to obtain repair materials through conversation and t
 | **Game freezes after entering name (Windows)** | Fixed in v0.5.3 — update to the latest version. Caused by llama-cpp-python redirecting stdout during model load |
 | **Game hangs during conversation** | LLM inference can be slow on CPU. Press `Ctrl+C` to exit safely. Progress is auto-saved |
 | **Where are save files?** | `~/.moonwalker/saves/` (SQLite). Run `config` to view/change location |
+| **Need to reinstall / reset** | Run `moon-traveler self remove` to clear the cached Python environment, then re-run the binary |
+
+### Uninstall
+
+For binary installs (PyApp), the binary includes management commands:
+
+```bash
+moon-traveler self remove    # Remove cached Python environment and packages
+moon-traveler self update    # Update the embedded application
+moon-traveler self restore   # Restore the cached environment
+```
+
+To fully uninstall, run `self remove` then delete the binary and `~/.moonwalker/` directory.
 
 ### User Data
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,7 +72,7 @@ These are not foolproof — small models (2B parameters) can be gradually jailbr
 - Auto-compaction triggers at 2,048 characters
 - Located in `src/llm.py`, `update_creature_memory()`
 
-### Layer 5: Download Integrity (v0.5.0)
+### Layer 5: Download Integrity (v0.5.0, expanded v0.5.4)
 
 **Model checksum verification** via SHA-256:
 
@@ -80,6 +80,22 @@ These are not foolproof — small models (2B parameters) can be gradually jailbr
 - Mismatched files are deleted automatically
 - Custom/manually-placed models show a warning: "Integrity not verified — ensure you trust the source"
 - Located in `src/llm.py`, `_verify_checksum()` and `_download_file()`
+
+**Binary upgrade checksum verification** via SHA-256 (v0.5.4):
+
+- The `update` command downloads the `.sha256` checksum file from GitHub Releases alongside the binary
+- SHA-256 hash is computed and compared before replacing the running binary
+- Mismatched downloads are rejected — the upgrade is aborted
+- If no checksum is available (older releases), a warning is shown but the upgrade proceeds
+- URL domain validation: only `github.com` and `githubusercontent.com` are accepted
+- Located in `src/upgrade.py`, `_verify_checksum()`, `_fetch_checksum()`, `_find_checksum_asset()`
+
+**Installation script checksum verification** (v0.5.4):
+
+- `install.sh` downloads the `.sha256` file and validates using `sha256sum` or `shasum -a 256`
+- `install.ps1` downloads the `.sha256` file and validates using `Get-FileHash -Algorithm SHA256`
+- Mismatched downloads abort installation with a tamper warning
+- If no checksum tool or file is available, a warning is shown
 
 **Custom model downloads** support HuggingFace URLs:
 
@@ -136,7 +152,7 @@ These are not foolproof — small models (2B parameters) can be gradually jailbr
 
 **Dev mode log file permissions**: The dev diagnostics log is created with default file permissions. Dev mode is opt-in and off by default.
 
-**curl/bash install pattern**: The install scripts download and run a binary from GitHub Releases over HTTPS. This is an industry-standard pattern. Users should verify release checksums.
+**curl/bash install pattern**: The install scripts download and run a binary from GitHub Releases over HTTPS. SHA-256 checksums are verified automatically when available (v0.5.4+). HTTPS provides transport security; checksums provide integrity verification.
 
 ## Data Storage
 

--- a/docs/beta.html
+++ b/docs/beta.html
@@ -77,10 +77,10 @@
   </p>
 
   <h3>macOS / Linux</h3>
-  <pre><code>curl -fsSL https://raw.githubusercontent.com/elephantatech/moon_traveler/main/install.sh | bash</code></pre>
+  <pre><code>curl -fsSL https://raw.githubusercontent.com/elephantatech/moon_traveler/main/install.sh | bash -s -- --beta</code></pre>
 
   <h3>Windows (PowerShell)</h3>
-  <pre><code>irm https://raw.githubusercontent.com/elephantatech/moon_traveler/main/install.ps1 | iex</code></pre>
+  <pre><code>& ([scriptblock]::Create((irm https://raw.githubusercontent.com/elephantatech/moon_traveler/main/install.ps1))) -Beta</code></pre>
 
   <h3>From Source (latest main)</h3>
   <pre><code>git clone https://github.com/elephantatech/moon_traveler.git

--- a/docs/how-to-play.html
+++ b/docs/how-to-play.html
@@ -709,11 +709,24 @@
     <table>
       <thead><tr><th>Flag</th><th>What it does</th></tr></thead>
       <tbody>
+        <tr><td><code>--help, -h</code></td><td>Show all options</td></tr>
+        <tr><td><code>--dev</code></td><td>Launch with dev diagnostics on</td></tr>
+        <tr><td><code>--super</code></td><td>Max trust, all items, full upgrades (testing)</td></tr>
         <tr><td><code>--upgrade</code></td><td>Check for game updates and exit</td></tr>
         <tr><td><code>--disable-animation</code></td><td>Launch with animations off</td></tr>
-        <tr><td><code>--dev</code></td><td>Launch with dev diagnostics on</td></tr>
       </tbody>
     </table>
+
+    <h3>PyApp Management (binary installs only)</h3>
+    <table>
+      <thead><tr><th>Command</th><th>What it does</th></tr></thead>
+      <tbody>
+        <tr><td><code>moon-traveler self remove</code></td><td>Remove cached Python environment and packages</td></tr>
+        <tr><td><code>moon-traveler self update</code></td><td>Update the embedded application</td></tr>
+        <tr><td><code>moon-traveler self restore</code></td><td>Restore the cached environment</td></tr>
+      </tbody>
+    </table>
+    <p>To fully uninstall: run <code>self remove</code>, delete the binary, and remove <code>~/.moonwalker/</code>.</p>
   </section>
 
   <section class="guide-section" id="tips">

--- a/install.ps1
+++ b/install.ps1
@@ -1,19 +1,46 @@
 # Moon Traveler Terminal — Windows installer (PowerShell)
-# Usage: irm https://raw.githubusercontent.com/elephantatech/moon_traveler/main/install.ps1 | iex
+#
+# Stable:  irm https://raw.githubusercontent.com/elephantatech/moon_traveler/main/install.ps1 | iex
+# Beta:    & ([scriptblock]::Create((irm https://raw.githubusercontent.com/elephantatech/moon_traveler/main/install.ps1))) -Beta
+# Alt:     $env:MOON_TRAVELER_BETA=1; irm https://raw.githubusercontent.com/elephantatech/moon_traveler/main/install.ps1 | iex
+
+param(
+    [switch]$Beta
+)
+
 $ErrorActionPreference = "Stop"
 
 $Repo = "elephantatech/moon_traveler"
 $InstallDir = if ($env:MOON_TRAVELER_INSTALL_DIR) { $env:MOON_TRAVELER_INSTALL_DIR } else { "$env:LOCALAPPDATA\Programs\moon-traveler" }
 
+# Support both -Beta parameter and environment variable
+if ($env:MOON_TRAVELER_BETA -eq "1") { $Beta = $true }
+
 Write-Host ""
 Write-Host "Moon Traveler Terminal Installer" -ForegroundColor Cyan
 Write-Host ""
 
-# Get latest version
-Write-Host "  Checking latest version..." -ForegroundColor DarkGray
-$Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
-$Version = $Release.tag_name
-Write-Host "  Latest version: $Version" -ForegroundColor DarkGray
+# Get version (beta or stable)
+if ($Beta) {
+    Write-Host ""
+    Write-Host "  BETA: This build may be unstable and is under active development." -ForegroundColor Yellow
+    Write-Host "  Re-run without MOON_TRAVELER_BETA=1 to install the latest stable release." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "  Checking latest beta..." -ForegroundColor DarkGray
+    $Releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases"
+    $PreRelease = $Releases | Where-Object { $_.prerelease -eq $true } | Select-Object -First 1
+    if (-not $PreRelease) {
+        Write-Host "  No beta releases found. Install the stable version instead." -ForegroundColor Red
+        exit 1
+    }
+    $Version = $PreRelease.tag_name
+    Write-Host "  Latest beta: $Version" -ForegroundColor DarkGray
+} else {
+    Write-Host "  Checking latest version..." -ForegroundColor DarkGray
+    $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
+    $Version = $Release.tag_name
+    Write-Host "  Latest version: $Version" -ForegroundColor DarkGray
+}
 
 # Download single binary (PyApp)
 $Filename = "moon-traveler-$Version-windows.exe"
@@ -55,7 +82,11 @@ if ($UserPath -notlike "*$InstallDir*") {
 }
 
 Write-Host ""
-Write-Host "  Moon Traveler Terminal $Version installed!" -ForegroundColor Green
+if ($Beta) {
+    Write-Host "  Moon Traveler Terminal $Version (beta) installed!" -ForegroundColor Green
+} else {
+    Write-Host "  Moon Traveler Terminal $Version installed!" -ForegroundColor Green
+}
 Write-Host ""
 Write-Host "  Location: $Dest" -ForegroundColor DarkGray
 Write-Host "  Data:     $env:USERPROFILE\.moonwalker\" -ForegroundColor DarkGray

--- a/install.ps1
+++ b/install.ps1
@@ -63,6 +63,30 @@ try {
     exit 1
 }
 
+# Verify SHA-256 checksum
+$ChecksumUrl = "$Url.sha256"
+try {
+    $ProgressPreference = 'SilentlyContinue'
+    $ChecksumContent = (Invoke-WebRequest -Uri $ChecksumUrl -UseBasicParsing).Content
+    $ProgressPreference = 'Continue'
+    $ExpectedHash = ($ChecksumContent -split '\s+')[0].Trim()
+    if ($ExpectedHash.Length -eq 64) {
+        Write-Host "  Verifying integrity (SHA-256)..." -ForegroundColor DarkGray
+        $ActualHash = (Get-FileHash -Path $TmpFile -Algorithm SHA256).Hash.ToLower()
+        if ($ActualHash -ne $ExpectedHash) {
+            Write-Host "  Checksum verification failed!" -ForegroundColor Red
+            Write-Host "  Expected: $($ExpectedHash.Substring(0,16))..." -ForegroundColor Red
+            Write-Host "  Got:      $($ActualHash.Substring(0,16))..." -ForegroundColor Red
+            Write-Host "  The downloaded file may be corrupted or tampered with." -ForegroundColor Red
+            Remove-Item $TmpDir -Recurse -Force
+            exit 1
+        }
+        Write-Host "  Checksum verified." -ForegroundColor DarkGray
+    }
+} catch {
+    Write-Host "  No checksum available — skipping verification." -ForegroundColor Yellow
+}
+
 # Install binary
 if (-not (Test-Path $InstallDir)) {
     New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
 # Moon Traveler Terminal — cross-platform installer
 # Usage: curl -fsSL https://raw.githubusercontent.com/elephantatech/moon_traveler/main/install.sh | bash
+# Beta:  curl -fsSL https://raw.githubusercontent.com/elephantatech/moon_traveler/main/install.sh | bash -s -- --beta
 set -euo pipefail
 
 REPO="elephantatech/moon_traveler"
 INSTALL_DIR="${MOON_TRAVELER_INSTALL_DIR:-$HOME/.local/bin}"
+BETA=false
+
+# Parse arguments
+for arg in "$@"; do
+  case "$arg" in
+    --beta) BETA=true ;;
+  esac
+done
 
 # Colors
 red()    { printf '\033[0;31m%s\033[0m\n' "$*"; }
@@ -95,16 +104,33 @@ check_compiler() {
   fi
 }
 
-# Get latest release tag from GitHub API
+# Get release tag from GitHub API
 get_latest_version() {
-  VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
-    | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+  if $BETA; then
+    yellow ""
+    yellow "  BETA: This build may be unstable and is under active development."
+    yellow "  Re-run without --beta to install the latest stable release."
+    yellow ""
+    VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases" \
+      | grep -B2 '"prerelease": true' | grep '"tag_name"' | head -1 \
+      | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
 
-  if [ -z "$VERSION" ]; then
-    red "Failed to detect latest version."
-    exit 1
+    if [ -z "$VERSION" ]; then
+      red "No beta releases found. Install the stable version instead:"
+      red "  curl -fsSL https://raw.githubusercontent.com/$REPO/main/install.sh | bash"
+      exit 1
+    fi
+    dim "Latest beta: $VERSION"
+  else
+    VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+      | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+
+    if [ -z "$VERSION" ]; then
+      red "Failed to detect latest version."
+      exit 1
+    fi
+    dim "Latest version: $VERSION"
   fi
-  dim "Latest version: $VERSION"
 }
 
 # Download and install
@@ -128,7 +154,11 @@ install() {
   chmod +x "$dest"
 
   echo
-  green "Moon Traveler Terminal $VERSION installed!"
+  if $BETA; then
+    green "Moon Traveler Terminal $VERSION (beta) installed!"
+  else
+    green "Moon Traveler Terminal $VERSION installed!"
+  fi
   echo
   dim "  Binary: $dest"
   dim "  Data:   ~/.moonwalker/"

--- a/install.sh
+++ b/install.sh
@@ -150,6 +150,36 @@ install() {
     exit 1
   }
 
+  # Verify SHA-256 checksum
+  local checksum_url="${url}.sha256"
+  local expected_hash
+  expected_hash=$(curl -fsSL "$checksum_url" 2>/dev/null | awk '{print $1}')
+  if [ -n "$expected_hash" ]; then
+    dim "Verifying integrity (SHA-256)..."
+    local actual_hash
+    if command -v sha256sum >/dev/null 2>&1; then
+      actual_hash=$(sha256sum "$TMP_DEST" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+      actual_hash=$(shasum -a 256 "$TMP_DEST" | awk '{print $1}')
+    else
+      yellow "  No sha256sum or shasum found — skipping verification."
+      actual_hash=""
+    fi
+    if [ -n "$actual_hash" ]; then
+      if [ "$actual_hash" != "$expected_hash" ]; then
+        red "Checksum verification failed!"
+        red "  Expected: ${expected_hash:0:16}..."
+        red "  Got:      ${actual_hash:0:16}..."
+        red "  The downloaded file may be corrupted or tampered with."
+        rm -f "$TMP_DEST"
+        exit 1
+      fi
+      dim "  Checksum verified."
+    fi
+  else
+    yellow "  No checksum available — skipping verification."
+  fi
+
   mv "$TMP_DEST" "$dest"
   chmod +x "$dest"
 

--- a/play_tui.py
+++ b/play_tui.py
@@ -1,10 +1,12 @@
 """Launch Moon Traveler in Textual TUI mode.
 
 Usage:
-    python play_tui.py              Normal game
-    python play_tui.py --dev        Start with dev mode enabled
-    python play_tui.py --super      Start with super mode (max trust, all items, full upgrades)
-    python play_tui.py --dev --super  Both
+    python play_tui.py                    Normal game
+    python play_tui.py --help             Show all options
+    python play_tui.py --dev              Start with developer diagnostics
+    python play_tui.py --super            Max trust, all items, full upgrades (testing)
+    python play_tui.py --upgrade          Check for game updates
+    python play_tui.py --disable-animation  No ASCII animations
 """
 
 import sys

--- a/spec.md
+++ b/spec.md
@@ -1164,7 +1164,7 @@ src/
   __init__.py              Package marker
   __main__.py              Module entry point
   animations.py            ASCII frame animations (scan, travel, look, drone, hazard sprites)
-  upgrade.py               In-place upgrade via GitHub Releases API
+  upgrade.py               In-place upgrade via GitHub Releases API, SHA-256 checksum validation
   game.py                  Main loop, init, win/lose, --dev/--super/--upgrade/--disable-animation flags
   world.py                 World generation, Location dataclass, MODE_CONFIG
   player.py                Player dataclass, resource management, ship_storage

--- a/src/game.py
+++ b/src/game.py
@@ -389,14 +389,38 @@ def game_loop(ctx: GameContext) -> bool:
 
 
 def _parse_flags() -> tuple[bool, bool, bool, bool]:
-    """Parse command-line flags."""
-    import sys
+    """Parse command-line flags using argparse."""
+    import argparse
 
-    dev_flag = "--dev" in sys.argv
-    super_flag = "--super" in sys.argv
-    upgrade_flag = "--upgrade" in sys.argv
-    no_anim_flag = "--disable-animation" in sys.argv
-    return dev_flag, super_flag, upgrade_flag, no_anim_flag
+    parser = argparse.ArgumentParser(
+        prog="moon-traveler",
+        description="Moon Traveler Terminal — Survive Saturn's Moon",
+        epilog=(
+            "Data: ~/.moonwalker/  (saves, models, config, dev logs)\n"
+            "\n"
+            "PyApp management (binary builds only):\n"
+            "  moon-traveler self remove   Remove cached Python environment and packages\n"
+            "  moon-traveler self update   Update the embedded application\n"
+            "  moon-traveler self restore  Restore the cached environment"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--dev", action="store_true", help="start with developer diagnostics enabled")
+    parser.add_argument(
+        "--super",
+        action="store_true",
+        dest="super_mode",
+        help="start with max trust, all items, full upgrades (testing)",
+    )
+    parser.add_argument("--upgrade", action="store_true", help="check for and install game updates, then exit")
+    parser.add_argument(
+        "--disable-animation",
+        action="store_true",
+        help="disable ASCII animations for this session",
+    )
+
+    args = parser.parse_args()
+    return args.dev, args.super_mode, args.upgrade, args.disable_animation
 
 
 def _setup_logging(dev: bool) -> None:

--- a/src/tui_app.py
+++ b/src/tui_app.py
@@ -346,6 +346,14 @@ def run_tui():
     """Launch the Textual TUI."""
     import sys
 
+    # Handle --help before starting the TUI (argparse runs inside the worker
+    # thread via game.main(), but --help must print to the raw terminal)
+    if "--help" in sys.argv or "-h" in sys.argv:
+        from src.game import _parse_flags
+
+        _parse_flags()  # prints help and calls sys.exit(0)
+        return
+
     if sys.platform == "win32":
         # Prevent WriterThread crashes on Unicode characters (░, █, ═, °, ⏱, —)
         # when Windows console defaults to cp1252 encoding.  If the thread dies,

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -96,6 +96,55 @@ def _find_platform_asset(assets: list, plat: str) -> dict | None:
     return None
 
 
+def _find_checksum_asset(assets: list, binary_name: str) -> dict | None:
+    """Find the .sha256 checksum asset for a given binary."""
+    checksum_name = f"{binary_name}.sha256".lower()
+    for asset in assets:
+        if asset.get("name", "").lower() == checksum_name:
+            return asset
+    return None
+
+
+def _fetch_checksum(url: str) -> str | None:
+    """Download a .sha256 file and return the hex hash.
+
+    Expected format: ``<hex_hash>  <filename>\\n``
+    """
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "moon-traveler"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            content = resp.read().decode().strip()
+        # Parse BSD/GNU checksum format: "hash  filename"
+        parts = content.split()
+        if parts and len(parts[0]) == 64:
+            return parts[0]
+        logger.warning("Unexpected checksum file format: %s", content[:80])
+        return None
+    except Exception as e:
+        logger.warning("Could not download checksum: %s", e)
+        return None
+
+
+def _verify_checksum(file_path: Path, expected_hash: str) -> bool:
+    """Verify SHA-256 hash of a file. Returns True if valid."""
+    import hashlib
+
+    ui.dim("  Verifying integrity (SHA-256)...")
+    sha256 = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        while chunk := f.read(8192):
+            sha256.update(chunk)
+    actual = sha256.hexdigest()
+    if actual != expected_hash:
+        ui.error("Checksum verification failed!")
+        ui.error(f"  Expected: {expected_hash[:16]}...")
+        ui.error(f"  Got:      {actual[:16]}...")
+        ui.error("  The downloaded file may be corrupted or tampered with.")
+        return False
+    ui.dim("  Checksum verified.")
+    return True
+
+
 def _is_editable_install() -> bool:
     """Check if running from a pip editable install (source checkout)."""
     if getattr(sys, "frozen", False):
@@ -257,6 +306,19 @@ def run_upgrade():
             ui.error(f"Download incomplete: got {actual_size} bytes, expected {expected_size}.")
             ui.dim(f"Manual download: {release['html_url']}")
             return
+
+        # Verify SHA-256 checksum
+        checksum_asset = _find_checksum_asset(release["assets"], asset_name)
+        if checksum_asset:
+            expected_hash = _fetch_checksum(checksum_asset["browser_download_url"])
+            if expected_hash:
+                if not _verify_checksum(tmp_file, expected_hash):
+                    ui.dim(f"Manual download: {release['html_url']}")
+                    return
+            else:
+                ui.warn("Could not parse checksum file — skipping verification.")
+        else:
+            ui.warn("No checksum available for this release — skipping verification.")
 
         # Binary install — direct replacement
         if _is_binary_install():

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -5,10 +5,10 @@ import logging
 import os
 import platform
 import shutil
+import stat
 import sys
 import tempfile
 import urllib.request
-import zipfile
 from pathlib import Path
 
 from src import ui
@@ -82,10 +82,16 @@ def check_for_update() -> dict | None:
 
 
 def _find_platform_asset(assets: list, plat: str) -> dict | None:
-    """Find the download asset matching the current platform."""
+    """Find the download asset matching the current platform.
+
+    Matches bare binaries (PyApp), .zip, and .tar.gz assets.
+    Skips .sha256 checksum files.
+    """
     for asset in assets:
         name = asset.get("name", "").lower()
-        if plat in name and (name.endswith(".zip") or name.endswith(".tar.gz")):
+        if name.endswith(".sha256"):
+            continue
+        if plat in name:
             return asset
     return None
 
@@ -98,6 +104,65 @@ def _is_editable_install() -> bool:
     pyproject = src_dir.parent / "pyproject.toml"
     git_dir = src_dir.parent / ".git"
     return pyproject.exists() and git_dir.exists()
+
+
+def _is_binary_install() -> bool:
+    """Check if running from a PyApp binary."""
+    exe = Path(sys.executable)
+    name = exe.name.lower()
+    return "moon-traveler" in name or "moon_traveler" in name
+
+
+def _get_binary_path() -> Path:
+    """Get the path to the currently running binary."""
+    return Path(sys.executable).resolve()
+
+
+def _replace_binary(new_binary: Path, target: Path) -> bool:
+    """Replace the running binary with a new one.
+
+    On Windows the running exe is locked, so we rename the old binary
+    first (Windows allows renaming a locked file), then move the new
+    one into place.
+    """
+    backup = target.with_suffix(target.suffix + ".old")
+
+    try:
+        # Remove any leftover backup from a previous upgrade
+        if backup.exists():
+            backup.unlink()
+
+        # Rename current binary to .old (works even on locked Windows exe)
+        target.rename(backup)
+    except OSError as e:
+        logger.warning("Could not rename current binary: %s", e)
+        ui.error(f"Could not rename current binary: {e}")
+        return False
+
+    try:
+        # Move new binary into place
+        shutil.move(str(new_binary), str(target))
+        # Ensure executable permission on Unix
+        if sys.platform != "win32":
+            target.chmod(target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    except OSError as e:
+        logger.error("Could not install new binary: %s", e)
+        ui.error(f"Could not install new binary: {e}")
+        # Try to restore backup
+        try:
+            backup.rename(target)
+        except OSError:
+            ui.error(f"CRITICAL: Could not restore backup. Recover manually from: {backup}")
+        return False
+
+    # Clean up backup
+    try:
+        backup.unlink()
+    except OSError:
+        # On Windows the old exe may still be locked — it will be cleaned up next run
+        logger.debug("Could not remove backup %s (may be locked)", backup)
+
+    return True
 
 
 def run_upgrade():
@@ -143,7 +208,7 @@ def run_upgrade():
         ui.dim(f"Download manually: {release['html_url']}")
         return
 
-    asset_name = Path(asset["name"]).name  # strip any directory components
+    asset_name = Path(asset["name"]).name
     if not asset_name or ".." in asset_name:
         ui.error("Invalid asset name in release metadata. Aborting.")
         return
@@ -174,7 +239,7 @@ def run_upgrade():
     ui.info(f"Downloading {asset_name}...")
     tmp_dir = Path(tempfile.mkdtemp(prefix="moon-upgrade-"))
     tmp_file = tmp_dir / asset_name
-    success = False
+
     try:
         try:
             urllib.request.urlretrieve(asset_url, str(tmp_file))
@@ -193,24 +258,31 @@ def run_upgrade():
             ui.dim(f"Manual download: {release['html_url']}")
             return
 
-        # Extract and replace
-        game_dir = Path(sys.executable).parent
-        if not game_dir.is_dir():
-            game_dir = Path(__file__).parent.parent
+        # Binary install — direct replacement
+        if _is_binary_install():
+            target = _get_binary_path()
+            ui.dim(f"Replacing binary: {target}")
+            if _replace_binary(tmp_file, target):
+                ui.console.print()
+                ui.success(f"Upgraded to v{release['latest']}!")
+                ui.dim("Restart the game to use the new version.")
+                ui.dim("Your saves in ~/.moonwalker/ are untouched.")
+            return
 
+        # Archive install (legacy — .zip or .tar.gz)
         extract_dir = tmp_dir / "extracted"
         if asset_name.endswith(".zip"):
+            import zipfile
+
             with zipfile.ZipFile(tmp_file) as zf:
-                # Safe extraction: filter out absolute paths and path traversal
                 safe_names = [
                     n for n in zf.namelist() if not os.path.isabs(n) and ".." not in os.path.normpath(n).split(os.sep)
                 ]
                 zf.extractall(extract_dir, members=safe_names)
-        else:
+        elif asset_name.endswith((".tar.gz", ".tgz")):
             import tarfile
 
             with tarfile.open(tmp_file) as tf:
-                # Safe extraction: filter out absolute paths and path traversal
                 safe_members = []
                 for member in tf.getmembers():
                     norm = os.path.normpath(member.name)
@@ -218,8 +290,11 @@ def run_upgrade():
                         continue
                     safe_members.append(member)
                 tf.extractall(extract_dir, members=safe_members)
+        else:
+            ui.error(f"Unknown archive format: {asset_name}")
+            ui.dim(f"Manual download: {release['html_url']}")
+            return
 
-        # Find the extracted contents (may be in a subdirectory)
         contents = list(extract_dir.iterdir())
         if not contents:
             ui.error("Archive appears to be empty after extraction.")
@@ -232,20 +307,17 @@ def run_upgrade():
         ui.info("To complete the upgrade:")
         ui.console.print("  1. Close the game")
         ui.console.print(f"  2. Copy files from: [cyan]{source_dir}[/cyan]")
+        game_dir = Path(sys.executable).parent
         ui.console.print(f"     to: [cyan]{game_dir}[/cyan]")
         ui.console.print("  3. Restart the game")
         ui.console.print()
         ui.dim("Your saves in ~/.moonwalker/ are safe — they're never touched by upgrades.")
         ui.dim(f"Clean up when done: delete {tmp_dir}")
-        success = True
+
     except Exception as e:
-        ui.error(f"Extract failed: {e}")
+        ui.error(f"Upgrade failed: {e}")
         ui.dim(f"Manual download: {release['html_url']}")
     finally:
-        # Always clean up the downloaded archive
-        try:
-            tmp_file.unlink(missing_ok=True)
-        except Exception:
-            logger.debug("Temp file cleanup failed", exc_info=True)
-        if not success:
+        # Clean up temp files (but not if we told the user to copy from there)
+        if _is_binary_install():
             shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -76,9 +76,14 @@ class TestFindPlatformAsset:
     def test_returns_none_for_empty_assets(self):
         assert _find_platform_asset([], "linux") is None
 
-    def test_ignores_non_archive_files(self):
-        assets = [{"name": "moon-traveler-macos.dmg", "browser_download_url": "https://..."}]
+    def test_ignores_sha256_checksum_files(self):
+        assets = [{"name": "moon-traveler-macos.sha256", "browser_download_url": "https://..."}]
         assert _find_platform_asset(assets, "macos") is None
+
+    def test_matches_bare_binary(self):
+        assets = [{"name": "moon-traveler-v0.5.4-linux", "browser_download_url": "https://..."}]
+        result = _find_platform_asset(assets, "linux")
+        assert result is not None
 
     def test_case_insensitive_name_match(self):
         assets = [{"name": "Moon-Traveler-MACOS.zip", "browser_download_url": "https://..."}]

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -8,8 +8,11 @@ from unittest.mock import MagicMock, patch
 
 from src.upgrade import (
     _detect_platform,
+    _fetch_checksum,
+    _find_checksum_asset,
     _find_platform_asset,
     _is_editable_install,
+    _verify_checksum,
     check_for_update,
     get_current_version,
     run_upgrade,
@@ -296,3 +299,76 @@ class TestRunUpgradeSecurity:
             run_upgrade()
             dim_calls = [str(c) for c in mock_ui.dim.call_args_list]
             assert any("cancelled" in s for s in dim_calls)
+
+
+class TestFindChecksumAsset:
+    """Tests for _find_checksum_asset()."""
+
+    def test_finds_matching_checksum(self):
+        assets = [
+            {"name": "moon-traveler-v0.5.4-linux", "browser_download_url": "https://..."},
+            {"name": "moon-traveler-v0.5.4-linux.sha256", "browser_download_url": "https://checksum"},
+        ]
+        result = _find_checksum_asset(assets, "moon-traveler-v0.5.4-linux")
+        assert result is not None
+        assert result["name"] == "moon-traveler-v0.5.4-linux.sha256"
+
+    def test_returns_none_when_no_checksum(self):
+        assets = [{"name": "moon-traveler-v0.5.4-linux", "browser_download_url": "https://..."}]
+        assert _find_checksum_asset(assets, "moon-traveler-v0.5.4-linux") is None
+
+    def test_case_insensitive(self):
+        assets = [{"name": "Moon-Traveler-V0.5.4-Linux.SHA256", "browser_download_url": "https://..."}]
+        result = _find_checksum_asset(assets, "moon-traveler-v0.5.4-linux")
+        assert result is not None
+
+
+class TestFetchChecksum:
+    """Tests for _fetch_checksum()."""
+
+    def test_parses_bsd_format(self):
+        content = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2  moon-traveler-linux\n"
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = content.encode()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = _fetch_checksum("https://example.com/file.sha256")
+        assert result == "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+
+    def test_returns_none_on_network_error(self):
+        with patch("urllib.request.urlopen", side_effect=Exception("timeout")):
+            assert _fetch_checksum("https://example.com/file.sha256") is None
+
+    def test_returns_none_on_invalid_format(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"not a valid checksum"
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            assert _fetch_checksum("https://example.com/file.sha256") is None
+
+
+class TestVerifyChecksum:
+    """Tests for _verify_checksum()."""
+
+    def test_valid_checksum_passes(self):
+        import hashlib
+
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"test binary content")
+            tmp_path = Path(f.name)
+        try:
+            expected = hashlib.sha256(b"test binary content").hexdigest()
+            assert _verify_checksum(tmp_path, expected) is True
+        finally:
+            tmp_path.unlink()
+
+    def test_invalid_checksum_fails(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"test binary content")
+            tmp_path = Path(f.name)
+        try:
+            assert _verify_checksum(tmp_path, "0" * 64) is False
+        finally:
+            tmp_path.unlink()


### PR DESCRIPTION
## Summary

- **CLI argparse** — switched from `sys.argv` to `argparse` with `--help` support, PyApp management commands documented
- **Beta install flag** — `install.sh --beta` and `install.ps1 -Beta` download latest pre-release
- **Binary self-upgrade** — `update` command now directly replaces the running binary (rename-then-move, Windows-safe)
- **SHA-256 checksum validation** — binary upgrades and install scripts verify `.sha256` checksums from GitHub Releases before installation. Mismatched downloads abort with a tamper warning.
- **SECURITY.md** — Layer 5 updated to document automatic checksum validation
- **8 new tests** for checksum functions (388 total)

## Security flow

```
download binary → verify size → download .sha256 → verify SHA-256 → replace binary
```

If checksum fails → abort. If no checksum available (older releases) → warn and proceed.

## Test plan

- [x] 388 tests pass
- [x] Lint + format clean
- [x] Shellcheck passes on install.sh
- [ ] CI passes on all 3 platforms
- [ ] Manual: `update` command shows "Checksum verified" message
- [ ] Manual: tampered binary aborts with checksum error

🤖 Generated AI Assisted